### PR TITLE
Add opensearch support and redirect instead of open a new tab

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,6 +9,8 @@
         <link rel="stylesheet" href="stylesheets/pygment_trac.css" />
         <link rel="stylesheet" href="jquery-ui-1.10.3.custom/css/smoothness/jquery-ui-1.10.3.custom.min.css" />
 
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="plonesource.org search" />
+
         <link rel="icon" type="image/png" href="/favicon.png" />
 
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />

--- a/static/javascripts/package-search.js
+++ b/static/javascripts/package-search.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
           $("#package-search input").val('');
 
           var selected = ui.item.value;
-          window.open('https://github.com/'.concat(selected));
+          window.location = 'https://github.com/'.concat(selected);
         }
 
       }).focus();

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>plonesource.org search</ShortName>
+  <Description>Search for Plone, Zope and add-on packages from github.</Description>
+  <Tags>plone zope github source</Tags>
+  <Contact>support@4teamwork.ch</Contact>
+  <Url type="text/html"
+       template="http://plonesource.org/?q={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
The search definition was created based on the official [opensearch documentation](http://www.opensearch.org/Specifications/OpenSearch/1.1) and tested in google chrome. Though it would be better to check out this branch first to test it on the server since this configuration will only work on `plonesource.org`.

Opensearch will fill the `q` `GET` parameter. We parse the url in javascript to get this parameter and fill it into the autocomplete search.
If the autocomplete has only one match for the initial search it will instantly redirect.

Also if a repository is selected from the dropdown plonesource.org will now redirect instead of open a new tab.

PS: I used `support@4teamwork.ch` as contact email. Do you want to use your private or personal company email address?
